### PR TITLE
Fix error in Windows Server BioC build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ToxicoGx
 Type: Package
 Title: Analysis of Large-Scale Toxico-Genomic Data
-Version: 1.3.3
-Date: 2021-10-06
+Version: 1.3.4
+Date: 2021-10-13
 Authors@R: c(
   person("Sisira","Nair", email = "sisira.nair@uhnresearch.ca",
     role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # *News*
 
+## v1.3.4
+- Fix bug in tests when run on Windows due to uninherited namespace imports
+for testthat::context and testthat::expect_equal inside a bplapply call
+
 ## v1.3.3
 - Debugging BioC build ERROR caused by updates to CoreGx
+
 ## v1.3.2
 - Fix a bug in computeLimmaDiffExpr where subsetting a ToxicoSet doesn't subset
 the protocolData of a SummarizedExperiment, causing coercing to an ExpressionSet

--- a/tests/testthat/test-tSetClassAccessorMethods.R
+++ b/tests/testthat/test-tSetClassAccessorMethods.R
@@ -5,8 +5,8 @@ library(ToxicoGx)
 context("Testing TGGATESsmall object validity...")
 
 test_that("TGGATESsmall tSet has correct structure", {
-  data(TGGATESsmall)
-  expect_error(checkTSetStructure(TGGATESsmall), NA)
+    data(TGGATESsmall)
+    expect_error(checkTSetStructure(TGGATESsmall), NA)
 })
 
 #### tSet Acessor methods ####
@@ -14,14 +14,16 @@ context("Testing tSet Class Accessor Methods...")
 
 # @drug Slot
 test_that("@drug slot accessors produce expected results", {
-  data("TGGATESsmall")
-  context("External validation...")
-  expect_equal_to_reference(drugInfo(TGGATESsmall), "drugInfo.TGGATESsmall.rds")
-  expect_equal_to_reference(drugNames(TGGATESsmall), "drugNames.TGGATESsmall.rds")
+    data("TGGATESsmall")
+    context("External validation...")
+    expect_equal_to_reference(drugInfo(TGGATESsmall),
+        "drugInfo.TGGATESsmall.rds")
+    expect_equal_to_reference(drugNames(TGGATESsmall),
+        "drugNames.TGGATESsmall.rds")
 
-  context("Internal validation...")
-  expect_equal(drugInfo(TGGATESsmall), TGGATESsmall@drug)
-  expect_equal(drugNames(TGGATESsmall), TGGATESsmall@drug$drugid)
+    context("Internal validation...")
+    expect_equal(drugInfo(TGGATESsmall), TGGATESsmall@drug)
+    expect_equal(drugNames(TGGATESsmall), TGGATESsmall@drug$drugid)
 })
 
 # @annotation Slot
@@ -29,7 +31,8 @@ test_that("@annotation slot accessors produce expected results", {
     data("TGGATESsmall")
 
     context("External validation...")
-    expect_equal_to_reference(TGGATESsmall@annotation, "annotation.TGGATESsmall.rds")
+    expect_equal_to_reference(TGGATESsmall@annotation, 
+        "annotation.TGGATESsmall.rds")
     expect_equal_to_reference(name(TGGATESsmall), "name.TGGATESsmall.rds")
 
     context("Internal validation...")
@@ -44,14 +47,17 @@ test_that("@molecularProfiles slot accessors produce expected results", {
     expect_equal_to_reference(mDataNames(TGGATESsmall),
         "mDataNames.TGGATESsmall.rds")
     context("Internal validation...")
-    expect_equal(mDataNames(TGGATESsmall), names(TGGATESsmall@molecularProfiles))
+    expect_equal(mDataNames(TGGATESsmall), 
+        names(TGGATESsmall@molecularProfiles))
 
-    ## TODO:: Test this with incorrect tSet structure to determine if error messages
-    # print in the correct order
+    ## TODO:: Test this with incorrect tSet structure to determine if error
+    ##>messages print in the correct order
     for (name in names(TGGATESsmall@molecularProfiles)) {
         context("External validation...")
-        expect_equal_to_reference(molecularProfiles(TGGATESsmall, name)[, 1:100],
-            paste0(name, ".molecularProfiles.TGGATESsmall.rds"))
+        expect_equal_to_reference(
+            molecularProfiles(TGGATESsmall, name)[, 1:100],
+            paste0(name, ".molecularProfiles.TGGATESsmall.rds")
+        )
         expect_equal_to_reference(featureInfo(TGGATESsmall, name),
             paste0(name, ".featureInfo.TGGATESsmall.rds"))
         expect_equal_to_reference(fNames(TGGATESsmall, name),
@@ -60,83 +66,104 @@ test_that("@molecularProfiles slot accessors produce expected results", {
             paste0(name, ".phenoData.TGGATESsmall.rds"))
         context("Internal validation...")
         # expect_equal(molecularProfiles(TGGATESsmall, name),
-        #     SummarizedExperiment::assay(TGGATESsmall@molecularProfiles[[name]], 1))
+        #     assay(TGGATESsmall@molecularProfiles[[name]], 1))
         expect_equal(featureInfo(TGGATESsmall, name),
-            SummarizedExperiment::rowData(TGGATESsmall@molecularProfiles[[name]]))
+            rowData(TGGATESsmall@molecularProfiles[[name]]))
         expect_equal(fNames(TGGATESsmall, name),
-            rownames(SummarizedExperiment::rowData(TGGATESsmall@molecularProfiles[[name]])))
+            rownames(rowData(TGGATESsmall@molecularProfiles[[name]])))
         expect_equal(phenoInfo(TGGATESsmall, name),
-            SummarizedExperiment::colData(TGGATESsmall@molecularProfiles[[name]]))
+            colData(TGGATESsmall@molecularProfiles[[name]]))
     }
 })
 
 # @cell Slot
 test_that("@cell slot accessors produce expected results", {
-  data("TGGATESsmall")
+    data("TGGATESsmall")
 
-  context("External validation...")
-  expect_equal_to_reference(cellInfo(TGGATESsmall), "cellInfo.TGGATESsmall.rds")
-  expect_equal_to_reference(cellNames(TGGATESsmall), "cellNames.TGGATESsmall.rds")
+    context("External validation...")
+    expect_equal_to_reference(cellInfo(TGGATESsmall),
+        "cellInfo.TGGATESsmall.rds")
+    expect_equal_to_reference(cellNames(TGGATESsmall),
+        "cellNames.TGGATESsmall.rds")
 
-  context("Internal validation...")
-  expect_equal(cellInfo(TGGATESsmall), TGGATESsmall@cell)
-  expect_equal(cellNames(TGGATESsmall), TGGATESsmall@cell$cellid)
+    context("Internal validation...")
+    expect_equal(cellInfo(TGGATESsmall), TGGATESsmall@cell)
+    expect_equal(cellNames(TGGATESsmall), TGGATESsmall@cell$cellid)
 })
 
 # @sensitivty Slot
 test_that("@sensitivity slot accessors produce expected results", {
-  data("TGGATESsmall")
+    data("TGGATESsmall")
 
-  context("External validation...")
-  expect_equal_to_reference(sensitivityInfo(TGGATESsmall), "sensitivityInfo.TGGATESsmall.rds")
-  expect_equal_to_reference(sensitivityProfiles(TGGATESsmall), "sensitivitProfiles.TGGATESsmall.rds")
-  expect_equal_to_reference(sensitivityMeasures(TGGATESsmall), "sensitivityMeasures.TGGATESsmall.rds")
-  expect_equal_to_reference(sensNumber(TGGATESsmall), "sensNumber.TGGATESsmall.rds")
-
-  context("Internal validation...")
-  expect_equal(sensitivityInfo(TGGATESsmall), TGGATESsmall@sensitivity$info)
-  expect_equal(sensitivityProfiles(TGGATESsmall), TGGATESsmall@sensitivity$profiles)
-  expect_equal(sensitivityMeasures(TGGATESsmall), colnames(TGGATESsmall@sensitivity$profiles))
-  expect_equal(sensNumber(TGGATESsmall), TGGATESsmall@sensitivity$n)
+    context("External validation...")
+    expect_equal_to_reference(sensitivityInfo(TGGATESsmall),
+        "sensitivityInfo.TGGATESsmall.rds")
+    expect_equal_to_reference(sensitivityProfiles(TGGATESsmall),
+        "sensitivitProfiles.TGGATESsmall.rds")
+    expect_equal_to_reference(sensitivityMeasures(TGGATESsmall),
+        "sensitivityMeasures.TGGATESsmall.rds")
+    expect_equal_to_reference(sensNumber(TGGATESsmall), 
+        "sensNumber.TGGATESsmall.rds")  
+    context("Internal validation...")
+    expect_equal(sensitivityInfo(TGGATESsmall), TGGATESsmall@sensitivity$info)
+    expect_equal(sensitivityProfiles(TGGATESsmall), 
+        TGGATESsmall@sensitivity$profiles)
+    expect_equal(sensitivityMeasures(TGGATESsmall), 
+        colnames(TGGATESsmall@sensitivity$profiles))
+    expect_equal(sensNumber(TGGATESsmall), TGGATESsmall@sensitivity$n)
 })
 
 # @perturbation Slot
 test_that("@perturbation slot accessors produce expected results", {
-  data("TGGATESsmall")
-  context("External validation...")
-  expect_equal_to_reference(TGGATESsmall@perturbation, "perturbation.TGGATESsmall.rds")
-  expect_equal_to_reference(pertNumber(TGGATESsmall), "pertNumber.TGGATESsmall.rds")
-  context("Internal validation...")
-  expect_equal(pertNumber(TGGATESsmall), TGGATESsmall@perturbation$n)
+    data("TGGATESsmall")
+    context("External validation...")
+    expect_equal_to_reference(TGGATESsmall@perturbation,
+        "perturbation.TGGATESsmall.rds")
+    expect_equal_to_reference(pertNumber(TGGATESsmall),
+        "pertNumber.TGGATESsmall.rds")
+    context("Internal validation...")
+    expect_equal(pertNumber(TGGATESsmall), TGGATESsmall@perturbation$n)
 })
 
 # @curation Slot
 test_that("@curation slot accessors produce expected results", {
-  data("TGGATESsmall")
-  context("External validation...")
-  expect_equal_to_reference(TGGATESsmall@curation, "curation.TGGATESsmall.rds")
+    data("TGGATESsmall")
+    context("External validation...")
+    expect_equal_to_reference(TGGATESsmall@curation, 
+        "curation.TGGATESsmall.rds")
 })
 
 # subsetTo Method
 test_that("subsetTo() class method produces expected results", {
-  data("TGGATESsmall")
+    data("TGGATESsmall")
 
-  ## TODO:: Add unit tests for `[` subset operator
-  ## TODO:: Change context() messages to be more informative when running devtools::test()
-  context("External validation...")
-  expect_equal_to_reference(subsetTo(
-    TGGATESsmall, drugs = drugNames(TGGATESsmall)[1], cell_lines=cellNames(TGGATESsmall)[1]),
-    "subsetTo.TGGATESsmall.rds")
-  context("Internal validation...")
-  ## Tests that subsetting molecularProfiles on duration works
-  expect_equal(all(ToxicoGx::sensitivityInfo(ToxicoGx::subsetTo(TGGATESsmall, duration = "2"))$duration_h %in% "2"), TRUE)
-  # Tests that relationship between sensitivity experiments and molecularProfiles is preserved (4 molecular Profiles / 1 sensitivity experiment)
-  BiocParallel::bplapply(names(TGGATESsmall@molecularProfiles),
-                     function(name) {
-                       context(paste0("Testing subsetTo on molecularProfile for ", name))
-                       ## TODO:: Generalize duration arguement so that it uses the first unique duration value in tSet (replace "8" with this)
-                       expect_equal(all(SummarizedExperiment::colData(
-                         ToxicoGx::subsetTo(TGGATESsmall, duration = "8")@molecularProfiles[[name]])$duration %in% "8"),
-                         TRUE)
-                      })
+    ## TODO:: Add unit tests for `[` subset operator
+    ## TODO:: Change context() messages to be more informative when 
+    ##>running devtools::test()
+    context("External validation...")
+    expect_equal_to_reference(
+        subsetTo(TGGATESsmall, drugs = drugNames(TGGATESsmall)[1],
+            cell_lines=cellNames(TGGATESsmall)[1]),
+        "subsetTo.TGGATESsmall.rds")
+    context("Internal validation...")
+    ## Tests that subsetting molecularProfiles on duration works
+    expect_equal(all(
+        sensitivityInfo(subsetTo(TGGATESsmall, duration = "2"))$duration_h
+            %in% "2"),
+        TRUE)
+    # Tests that relationship between sensitivity experiments and
+    #>molecularProfiles is preserved 
+    #>(4 molecular Profiles / 1 sensitivity experiment)
+    BiocParallel::bplapply(names(TGGATESsmall@molecularProfiles),
+            function(name) {
+        testthat::context(paste0("Testing subsetTo on molecularProfile for ",
+            name))
+        ## TODO:: Generalize duration arguement so that it uses the first
+        ##>unique duration value in tSet (replace "8" with this)
+        testthat::expect_equal(all(
+            SummarizedExperiment::colData(
+                ToxicoGx::subsetTo(TGGATESsmall, duration = "8"
+                    )@molecularProfiles[[name]])$duration %in% "8"),
+            TRUE)
+    })
 })


### PR DESCRIPTION
* Use of non-shared memory parallelism on Windows results in failure to inherit namespace imports
for `testthat` functions
* Fix is to call the functions with explicit namespace like `testthat::context()`
* Version bump for BioC build and update to NEWS.md